### PR TITLE
Fixes rosjava/android_extras#18. Bumped compileSdkVersion to 25.

### DIFF
--- a/android_tutorial_hokuyo/build.gradle
+++ b/android_tutorial_hokuyo/build.gradle
@@ -23,5 +23,5 @@ dependencies {
 apply plugin: 'com.android.application'
 
 android {
-  compileSdkVersion 15
+  compileSdkVersion 25
 }

--- a/ros_master_browser/build.gradle
+++ b/ros_master_browser/build.gradle
@@ -22,6 +22,6 @@ dependencies {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 10
+    compileSdkVersion 25 
 }
 


### PR DESCRIPTION
@adamantivm do you agree this is the correct solution? After adding the bumped sdk version I got android_extras to compile. Let me know if you need me to change anything. 